### PR TITLE
Revert "ci: dependabotの対象をexamplesも含めて実施する"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,7 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/**"
-      - "/examples"
+    directory: "/"
     groups:
       all:
         patterns:


### PR DESCRIPTION
This reverts commit 460dd7c465e15e1c30471dbc054e713f2a2765e3.

exampleのpackage.jsonの変更がpnpm-lock.yamlに反映されないため、戻す