### PR TITLE
ci: publish時にキャッシュ利用しない

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           run_install: false
-          cache: true
+          # pnpmキャッシュを使用しない。キャッシュが汚染されるとそれがリリースされる可能性がある
+          cache: false
 
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
キャッシュが汚染された場合、汚染されたままリリースする恐れがある