### PR TITLE
chore: bump version 2026.7.0 -> 2026.7.1

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2026.7.0"
+current_version = "v2026.7.1"
 version_pattern = "vYYYY.MM.INC0"
 commit_message = "chore: bump version {old_version_pep440} -> {new_version_pep440}"
 pre_commit_hook = ""

--- a/packages/amplify-auth-hooks/package.json
+++ b/packages/amplify-auth-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/amplify-auth-hooks",
-  "version": "2026.7.0",
+  "version": "2026.7.1",
   "description": "Hooks for Amplify Auth",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リリース**
  - プロジェクトおよび認証フックパッケージのバージョンを、2026.7.0 から 2026.7.1 に更新しました。
  - 今回の更新により、最新のパッチリリースとして提供されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->