### PR TITLE
chore: bump version 2026.7.2 -> 2026.8.0

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2026.7.2"
+current_version = "v2026.8.0"
 version_pattern = "vYYYY.MM.INC0"
 commit_message = "chore: bump version {old_version_pep440} -> {new_version_pep440}"
 pre_commit_hook = ""

--- a/packages/amplify-auth-hooks/package.json
+++ b/packages/amplify-auth-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/amplify-auth-hooks",
-  "version": "2026.7.2",
+  "version": "2026.8.0",
   "description": "Hooks for Amplify Auth",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リリース**
  * アプリケーションおよび関連パッケージのバージョンを `2026.8.0` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->